### PR TITLE
Update full_touch_dropdown.dart

### DIFF
--- a/lib/src/components/full_touch_dropdown.dart
+++ b/lib/src/components/full_touch_dropdown.dart
@@ -39,7 +39,7 @@ class FullTouchDropdownState extends State<FullTouchDropdown> {
       style: TextButton.styleFrom(
         padding: EdgeInsets.zero,
         shadowColor: LibColors.transparent,
-        primary: LibColors.white,
+        backgroundColor: LibColors.white,
       ),
       onPressed: () {
         if (!widget.enabled) return;


### PR DESCRIPTION
primary' is deprecated and shouldn't be used. Use backgroundColor instead. This feature was deprecated after v3.1.0. Try replacing the use of the deprecated member with the replacement